### PR TITLE
Add mem.save option for Gaussian family

### DIFF
--- a/R/elnet.R
+++ b/R/elnet.R
@@ -1,5 +1,5 @@
 elnet=function(x,is.sparse,ix,jx,y,weights,offset,type.gaussian=c("covariance","naive"),alpha,nobs,nvars,jd,vp,cl,ne,nx,nlam,flmin,ulam,thresh,isd,intr,vnames,maxit,
-               beta0,isg,plam){
+               beta0,isg,plam,mem.save){
   maxit=as.integer(maxit)
   weights=as.double(weights)
   type.gaussian=match.arg(type.gaussian)
@@ -54,21 +54,22 @@ if(nulldev==0)stop("y is constant; gaussian glmnet fails at standardization step
          PACKAGE = "glmnetPlus"
     )
   } else {
-    if (data.table::is.data.table(x)) x <- as.matrix(x)
+    is.tbl <- data.table::is.data.table(x)
+    if (is.tbl) x <- as.matrix(x)
     dotCall64::.C64("elnet",
-         SIGNATURE = c("integer", "double", "integer", "integer", "double", "double",
-                       "double", "integer", "double", "double", "integer", "integer", "integer", "double",
-                       "double", "double", "integer", "integer", "integer", "double", "integer", "double",
-                       "integer", "double", "double", "integer", "integer",
-                       "double", "double", "integer", "integer", "double"),
-         ka, parm = alpha, nobs, nvars, x, y,
-         weights, jd, vp, cl, ne, nx, nlam, flmin,
-         ulam, thresh, isd, intr, maxit, beta0, isg, plam,
-         lmu = integer(1), a0 = double(nlam), ca = double(nx*nlam), ia = integer(nx), nin = integer(nlam),
-         rsq = double(nlam), alm = double(nlam), nlp = integer(1), jerr = integer(1), residuals = double(nobs*nlam),
-         INTENT = c(rep("r", 22), rep("w", 10)),
-         PACKAGE = "glmnetPlus"
-    )
+                    SIGNATURE = c("integer", "double", "integer", "integer", "double", "double",
+                                  "double", "integer", "double", "double", "integer", "integer", "integer", "double",
+                                  "double", "double", "integer", "integer", "integer", "double", "integer", "double",
+                                  "integer", "double", "double", "integer", "integer",
+                                  "double", "double", "integer", "integer", "double"),
+                    ka, parm = alpha, nobs, nvars, x, y,
+                    weights, jd, vp, cl, ne, nx, nlam, flmin,
+                    ulam, thresh, isd, intr, maxit, beta0, isg, plam,
+                    lmu = integer(1), a0 = double(nlam), ca = double(nx*nlam), ia = integer(nx), nin = integer(nlam),
+                    rsq = double(nlam), alm = double(nlam), nlp = integer(1), jerr = integer(1), residuals = double(nobs*nlam),
+                    INTENT = c(rep("rw", 4), ifelse(is.tbl||mem.save, "r", "rw"), rep("rw", 17), rep("w", 10)),
+                    PACKAGE = "glmnetPlus"
+                    )
   }
 
 if(fit$jerr!=0){

--- a/R/glmnet.R
+++ b/R/glmnet.R
@@ -1,6 +1,8 @@
 glmnet=function(x,y,family=c("gaussian","binomial","poisson","multinomial","cox","mgaussian"),weights,offset=NULL,alpha=1.0,nlambda=100,lambda.min.ratio=ifelse(nobs<nvars,1e-2,1e-4),lambda=NULL,standardize=TRUE,intercept=TRUE,thresh=1e-7,dfmax=nvars+1,pmax=min(dfmax*2+20,nvars),exclude,penalty.factor=rep(1,nvars),lower.limits=-Inf,upper.limits=Inf,maxit=100000,type.gaussian=ifelse(nvars<500,"covariance","naive"),type.logistic=c("Newton","modified.Newton"),standardize.response=FALSE,type.multinomial=c("ungrouped","grouped"),
-                beta0=NULL, is.glmnet.solution=FALSE, prev.lambda=NULL){
+                beta0=NULL, is.glmnet.solution=FALSE, prev.lambda=NULL, mem.save=FALSE){
 
+# mem.save  whether to save memory by passing x by reference to Fortran. If TRUE, make sure x has been copied
+#           outside of this call because it will be modified in place. Only supports the Gaussian family. 
 ### Prepare all the generic arguments, then hand off to family functions
 
 # QJY: allow data.table to avoid copy and save memory
@@ -113,7 +115,7 @@ glmnet=function(x,y,family=c("gaussian","binomial","poisson","multinomial","cox"
   kopt=as.integer(kopt)
 
   fit=switch(family,
-    "gaussian"=elnet(x,is.sparse,ix,jx,y,weights,offset,type.gaussian,alpha,nobs,nvars,jd,vp,cl,ne,nx,nlam,flmin,ulam,thresh,isd,intr,vnames,maxit,beta0,is.glmnet.solution,prev.lambda),
+    "gaussian"=elnet(x,is.sparse,ix,jx,y,weights,offset,type.gaussian,alpha,nobs,nvars,jd,vp,cl,ne,nx,nlam,flmin,ulam,thresh,isd,intr,vnames,maxit,beta0,is.glmnet.solution,prev.lambda,mem.save),
     "poisson"=fishnet(x,is.sparse,ix,jx,y,weights,offset,alpha,nobs,nvars,jd,vp,cl,ne,nx,nlam,flmin,ulam,thresh,isd,intr,vnames,maxit),
     "binomial"=lognet(x,is.sparse,ix,jx,y,weights,offset,alpha,nobs,nvars,jd,vp,cl,ne,nx,nlam,flmin,ulam,thresh,isd,intr,vnames,maxit,kopt,family),
     "multinomial"=lognet(x,is.sparse,ix,jx,y,weights,offset,alpha,nobs,nvars,jd,vp,cl,ne,nx,nlam,flmin,ulam,thresh,isd,intr,vnames,maxit,kopt,family),


### PR DESCRIPTION
It allows for pass-by-reference of the data matrix to the Fortran computation. The matrix itself will be modified though and only applicable when there is a copy of the data outside of this function call. Default is FALSE.